### PR TITLE
SecureRandom for Android caveats mitigated

### DIFF
--- a/app/src/main/java/co/nano/nanowallet/NanoUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/NanoUtil.java
@@ -4,12 +4,11 @@ package co.nano.nanowallet;
   Utilities for crypto functions
  */
 
+import co.nano.nanowallet.util.SecureRandomUtil;
 import org.libsodium.jni.NaCl;
 import org.libsodium.jni.Sodium;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Locale;
 import java.security.SecureRandom;
 
 public class NanoUtil {
@@ -25,7 +24,7 @@ public class NanoUtil {
      */
     public static String generateSeed() {
         int numchars = 64;
-        SecureRandom random = new SecureRandom();
+        SecureRandom random = SecureRandomUtil.secureRandom();
         StringBuilder sb = new StringBuilder();
         while (sb.length() < numchars) {
             sb.append(Integer.toHexString(random.nextInt()));

--- a/app/src/main/java/co/nano/nanowallet/util/LinuxSecureRandom.java
+++ b/app/src/main/java/co/nano/nanowallet/util/LinuxSecureRandom.java
@@ -1,0 +1,75 @@
+package co.nano.nanowallet.util;
+
+import android.util.Log;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.Provider;
+import java.security.SecureRandomSpi;
+import java.security.Security;
+
+public class LinuxSecureRandom extends SecureRandomSpi {
+    private static final FileInputStream urandom;
+
+    private static class LinuxSecureRandomProvider extends Provider {
+        public LinuxSecureRandomProvider() {
+            super("LinuxSecureRandom", 1.0, "A Linux specific random number provider that uses /dev/urandom");
+            put("SecureRandom.LinuxSecureRandom", LinuxSecureRandom.class.getName());
+        }
+    }
+
+    static {
+        try {
+            File file = new File("/dev/urandom");
+            // This stream is deliberately leaked.
+            urandom = new FileInputStream(file);
+            if (urandom.read() == -1)
+                throw new RuntimeException("/dev/urandom not readable?");
+            // Now override the default SecureRandom implementation with this one.
+            int position = Security.insertProviderAt(new LinuxSecureRandomProvider(), 1);
+
+            if (position != -1)
+                Log.i("INFO", "Secure randomness will be read from {} only: " + file);
+            else
+                Log.i("INFO", "Randomness is already secure.");
+        } catch (FileNotFoundException e) {
+            // Should never happen.
+            Log.e("ERROR", "/dev/urandom does not appear to exist or is not openable");
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            Log.e("ERROR", "/dev/urandom does not appear to be readable");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final DataInputStream dis;
+
+    public LinuxSecureRandom() {
+        // DataInputStream is not thread safe, so each random object has its own.
+        dis = new DataInputStream(urandom);
+    }
+
+    @Override
+    protected void engineSetSeed(byte[] bytes) {
+        // Ignore.
+    }
+
+    @Override
+    protected void engineNextBytes(byte[] bytes) {
+        try {
+            dis.readFully(bytes); // This will block until all the bytes can be read.
+        } catch (IOException e) {
+            throw new RuntimeException(e); // Fatal error. Do not attempt to recover from this.
+        }
+    }
+
+    @Override
+    protected byte[] engineGenerateSeed(int i) {
+        byte[] bits = new byte[i];
+        engineNextBytes(bits);
+        return bits;
+    }
+}

--- a/app/src/main/java/co/nano/nanowallet/util/SecureRandomUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/util/SecureRandomUtil.java
@@ -1,0 +1,33 @@
+package co.nano.nanowallet.util;
+
+import java.security.SecureRandom;
+
+public final class SecureRandomUtil {
+
+    private static final SecureRandom SECURE_RANDOM;
+
+    static {
+        if (isAndroidRuntime()) {
+            new LinuxSecureRandom();
+        }
+        SECURE_RANDOM = new SecureRandom();
+    }
+
+    public static SecureRandom secureRandom() {
+        return SECURE_RANDOM;
+    }
+
+    private static int isAndroid = -1;
+
+    static boolean isAndroidRuntime() {
+        if (isAndroid == -1) {
+            final String runtime = System.getProperty("java.runtime.name");
+            isAndroid = (runtime != null && runtime.equals("Android Runtime")) ? 1 : 0;
+        }
+        return isAndroid == 1;
+    }
+
+    private SecureRandomUtil() {
+    }
+
+}


### PR DESCRIPTION
A SecureRandom implementation which mitigates the problems of Android's SecureRandom caveats. Essentially a more secure way of generating seeds.

- The LinuxSecureRandom is a SecureRandom implementation that is able to override the standard JVM provided implementation, and which simply serves random numbers by reading /dev/urandom. 
- That is, it delegates to the kernel on UNIX systems and is unusable on other platforms. 
- Attempts to manually set the seed are ignored. There is no difference between seed bytes and non-seed bytes, they are all from the same source.

https://android-developers.googleblog.com/2013/08/some-securerandom-thoughts.html