### PR TITLE
1.0.2 Introduce flow to allow user to migrate to new account

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "co.nano.nanowallet"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 26
-        versionName "1.0.1"
+        versionCode 27
+        versionName "1.0.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/app/src/main/java/co/nano/nanowallet/MainActivity.java
+++ b/app/src/main/java/co/nano/nanowallet/MainActivity.java
@@ -25,6 +25,7 @@ import co.nano.nanowallet.bus.HideOverlay;
 import co.nano.nanowallet.bus.Logout;
 import co.nano.nanowallet.bus.OpenWebView;
 import co.nano.nanowallet.bus.RxBus;
+import co.nano.nanowallet.bus.SeedCreatedWithAnotherWallet;
 import co.nano.nanowallet.bus.ShowOverlay;
 import co.nano.nanowallet.di.activity.ActivityComponent;
 import co.nano.nanowallet.di.activity.ActivityModule;
@@ -238,6 +239,16 @@ public class MainActivity extends AppCompatActivity implements WindowControl, Ac
     @Subscribe
     public void hideOverlay(HideOverlay hideOverlay) {
         mOverlay.setVisibility(View.GONE);
+    }
+
+    @Subscribe
+    public void seedCreatedWithAnotherWallet(SeedCreatedWithAnotherWallet seedCreatedWithAnotherWallet) {
+        realm.executeTransaction(realm -> {
+            Credentials credentials = realm.where(Credentials.class).findFirst();
+            if (credentials != null) {
+                credentials.setSeedIsSecure(true);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/co/nano/nanowallet/NanoUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/NanoUtil.java
@@ -4,12 +4,11 @@ package co.nano.nanowallet;
   Utilities for crypto functions
  */
 
+import co.nano.nanowallet.util.SecureRandomUtil;
 import org.libsodium.jni.NaCl;
 import org.libsodium.jni.Sodium;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Locale;
 import java.security.SecureRandom;
 
 public class NanoUtil {
@@ -25,7 +24,7 @@ public class NanoUtil {
      */
     public static String generateSeed() {
         int numchars = 64;
-        SecureRandom random = new SecureRandom();
+        SecureRandom random = SecureRandomUtil.secureRandom();
         StringBuilder sb = new StringBuilder();
         while (sb.length() < numchars) {
             sb.append(Integer.toHexString(random.nextInt()));

--- a/app/src/main/java/co/nano/nanowallet/bus/SeedCreatedWithAnotherWallet.java
+++ b/app/src/main/java/co/nano/nanowallet/bus/SeedCreatedWithAnotherWallet.java
@@ -1,0 +1,5 @@
+package co.nano.nanowallet.bus;
+
+
+public class SeedCreatedWithAnotherWallet {
+}

--- a/app/src/main/java/co/nano/nanowallet/db/Migration.java
+++ b/app/src/main/java/co/nano/nanowallet/db/Migration.java
@@ -57,6 +57,15 @@ public class Migration implements RealmMigration {
             }
             oldVersion++;
         }
+
+        if (oldVersion == 6) {
+            RealmObjectSchema credentialsSchema = schema.get("Credentials");
+            if (credentialsSchema != null) {
+                credentialsSchema.addField("newlyGeneratedSeed", String.class);
+                credentialsSchema.addField("hasSentToNewSeed", Boolean.class);
+            }
+            oldVersion++;
+        }
     }
 
     @Override

--- a/app/src/main/java/co/nano/nanowallet/di/persistence/PersistenceModule.java
+++ b/app/src/main/java/co/nano/nanowallet/di/persistence/PersistenceModule.java
@@ -19,7 +19,7 @@ import io.realm.exceptions.RealmFileException;
 
 @Module
 public class PersistenceModule {
-    private static final int SCHEMA_VERSION = 6;
+    private static final int SCHEMA_VERSION = 7;
     private static final String DB_NAME = "nano.realm";
 
     @Provides

--- a/app/src/main/java/co/nano/nanowallet/model/Credentials.java
+++ b/app/src/main/java/co/nano/nanowallet/model/Credentials.java
@@ -20,6 +20,8 @@ public class Credentials extends RealmObject {
     private Boolean hasAgreedToTracking;
     private Boolean hasAnsweredAnalyticsQuestion;
     private Boolean seedIsSecure;
+    private String newlyGeneratedSeed;
+    private Boolean hasSentToNewSeed;
 
     public static final List<Character> VALID_SEED_CHARACTERS = Arrays.asList('a', 'b', 'c', 'd', 'e', 'f', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
 
@@ -96,6 +98,22 @@ public class Credentials extends RealmObject {
 
     public void setSeedIsSecure(Boolean seedIsSecure) {
         this.seedIsSecure = seedIsSecure;
+    }
+
+    public String getNewlyGeneratedSeed() {
+        return newlyGeneratedSeed;
+    }
+
+    public void setNewlyGeneratedSeed(String newlyGeneratedSeed) {
+        this.newlyGeneratedSeed = newlyGeneratedSeed;
+    }
+
+    public Boolean getHasSentToNewSeed() {
+        return hasSentToNewSeed;
+    }
+
+    public void setHasSentToNewSeed(Boolean hasSentToNewSeed) {
+        this.hasSentToNewSeed = hasSentToNewSeed;
     }
 
     // Generated fields

--- a/app/src/main/java/co/nano/nanowallet/model/Credentials.java
+++ b/app/src/main/java/co/nano/nanowallet/model/Credentials.java
@@ -109,7 +109,7 @@ public class Credentials extends RealmObject {
     }
 
     public Boolean getHasSentToNewSeed() {
-        return hasSentToNewSeed;
+        return hasSentToNewSeed == null ? false : hasSentToNewSeed;
     }
 
     public void setHasSentToNewSeed(Boolean hasSentToNewSeed) {

--- a/app/src/main/java/co/nano/nanowallet/network/AccountService.java
+++ b/app/src/main/java/co/nano/nanowallet/network/AccountService.java
@@ -101,6 +101,10 @@ public class AccountService {
         }
     }
 
+    public boolean isRequestQueueEmpty() {
+        return requestQueue.size() == 0;
+    }
+
     public void open() {
         wallet.setBlockCount(-1);
 

--- a/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
@@ -27,6 +27,7 @@ import co.nano.nanowallet.analytics.AnalyticsService;
 import co.nano.nanowallet.broadcastreceiver.ClipboardAlarmReceiver;
 import co.nano.nanowallet.bus.Logout;
 import co.nano.nanowallet.bus.RxBus;
+import co.nano.nanowallet.bus.SeedCreatedWithAnotherWallet;
 import co.nano.nanowallet.model.Credentials;
 import co.nano.nanowallet.ui.pin.CreatePinDialogFragment;
 import co.nano.nanowallet.ui.pin.PinDialogFragment;
@@ -291,6 +292,7 @@ public class BaseFragment extends Fragment {
                     addressDialog.show();
                 })
                 .setNegativeButton(R.string.seed_update_alert_cancel_cta, (dialog, which) -> {
+                    RxBus.get().post(new SeedCreatedWithAnotherWallet());
                 })
                 .show();
     }

--- a/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
@@ -5,7 +5,6 @@ import android.app.AlarmManager;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -14,11 +13,11 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
-import android.text.SpannableString;
+import android.text.InputType;
 import android.text.method.LinkMovementMethod;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import co.nano.nanowallet.NanoUtil;
@@ -274,16 +273,39 @@ public class BaseFragment extends Fragment {
 
                         copy.setOnClickListener(view -> {
                             ok.setOnClickListener(view2 -> {
-                                    if (getActivity() instanceof WindowControl) {
-                                        addressDialog.dismiss();
-                                        // navigate to send screen
-                                        ((WindowControl) getActivity()).getFragmentUtility().add(
-                                                SendFragment.newInstance(newSeed),
-                                                FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
-                                                FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
-                                                SendFragment.TAG
-                                        );
-                                    }
+                                addressDialog.dismiss();
+
+                                // create seed verify alert
+                                final EditText input = new EditText(getContext());
+                                input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+                                AlertDialog seedVerifyBuilder = new AlertDialog.Builder(getContext())
+                                        .setTitle(R.string.seed_update_verify_title)
+                                        .setView(input)
+                                        .setPositiveButton(R.string.seed_update_verify_confirm, null)
+                                        .setNegativeButton(R.string.seed_update_verify_cancel, (dialog22, which12) -> dialog22.cancel())
+                                        .create();
+
+                                seedVerifyBuilder.setOnShowListener(dialog32 -> {
+                                    Button ok2 = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_POSITIVE);
+                                    ok2.setOnClickListener(view3 -> {
+                                                if (input.getText().toString().equals(newSeed)) {
+                                                    if (getActivity() instanceof WindowControl) {
+                                                        // navigate to send screen
+                                                        dialog32.dismiss();
+                                                        ((WindowControl) getActivity()).getFragmentUtility().add(
+                                                                SendFragment.newInstance(newSeed),
+                                                                FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
+                                                                FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
+                                                                SendFragment.TAG
+                                                        );
+                                                    } else {
+                                                        addressDialog.setMessage(getString(R.string.seed_update_verify_message));
+                                                    }
+                                                }
+                                            }
+                                    );
+
+                                });
                             });
                             ok.setText(getString(R.string.seed_update_address_alert_confirm_cta));
                             ok.setVisibility(View.VISIBLE);

--- a/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
@@ -258,9 +258,10 @@ public class BaseFragment extends Fragment {
                 .setPositiveButton(R.string.seed_update_alert_confirm_cta, (dialog, which) -> {
                     dialog.dismiss();
                     String newSeed = NanoUtil.generateSeed();
+                    String newSeedDisplay = newSeed.replaceAll("(.{4})", "$1 ");
                     String address = NanoUtil.publicToAddress(NanoUtil.privateToPublic(NanoUtil.seedToPrivate(newSeed)));
                     AlertDialog addressDialog = builder.setTitle(R.string.seed_update_address_alert_title)
-                            .setMessage(getString(R.string.seed_update_address_alert_message, newSeed, address))
+                            .setMessage(getString(R.string.seed_update_address_alert_message, newSeedDisplay, address))
                             .setPositiveButton(null, null)
                             .setNegativeButton(R.string.seed_update_address_alert_neutral_cta, null)
                             .setCancelable(false)
@@ -271,13 +272,6 @@ public class BaseFragment extends Fragment {
                         Button ok = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_POSITIVE);
 
                         copy.setOnClickListener(view -> {
-                            // copy seed to clipboard
-                            android.content.ClipboardManager clipboard = (android.content.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-                            android.content.ClipData clip = android.content.ClipData.newPlainText("seed", newSeed);
-                            if (clipboard != null) {
-                                clipboard.setPrimaryClip(clip);
-                            }
-
                             ok.setOnClickListener(view2 -> {
                                     if (getActivity() instanceof WindowControl) {
                                         addressDialog.dismiss();
@@ -312,8 +306,9 @@ public class BaseFragment extends Fragment {
             builder = new AlertDialog.Builder(getContext());
         }
         String address = NanoUtil.publicToAddress(NanoUtil.privateToPublic(NanoUtil.seedToPrivate(seed)));
+        String newSeedDisplay = seed.replaceAll("(.{4})", "$1 ");
         AlertDialog reminderDialog = builder.setTitle(R.string.seed_reminder_alert_title)
-                .setMessage(getString(R.string.seed_reminder_alert_message, seed, address))
+                .setMessage(getString(R.string.seed_reminder_alert_message, newSeedDisplay, address))
                 .setPositiveButton(R.string.seed_reminder_alert_confirm_cta, null)
                 .setNegativeButton(R.string.seed_reminder_alert_neutral_cta, null)
                 .create();
@@ -323,12 +318,7 @@ public class BaseFragment extends Fragment {
             Button ok = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_POSITIVE);
 
             copy.setOnClickListener(view -> {
-                // copy seed to clipboard
-                android.content.ClipboardManager clipboard = (android.content.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-                android.content.ClipData clip = android.content.ClipData.newPlainText("seed", seed);
-                if (clipboard != null) {
-                    clipboard.setPrimaryClip(clip);
-                }
+                dialog1.dismiss();
             });
 
             ok.setOnClickListener(view2 -> {

--- a/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/common/BaseFragment.java
@@ -10,6 +10,8 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
+import android.support.design.widget.TextInputEditText;
+import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
@@ -17,7 +19,6 @@ import android.text.InputType;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.TextView;
 
 import co.nano.nanowallet.NanoUtil;
@@ -269,46 +270,48 @@ public class BaseFragment extends Fragment {
 
                     addressDialog.setOnShowListener(dialog1 -> {
                         Button copy = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_NEGATIVE);
-                        Button ok = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_POSITIVE);
 
                         copy.setOnClickListener(view -> {
-                            ok.setOnClickListener(view2 -> {
-                                addressDialog.dismiss();
+                            addressDialog.dismiss();
 
-                                // create seed verify alert
-                                final EditText input = new EditText(getContext());
-                                input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-                                AlertDialog seedVerifyBuilder = new AlertDialog.Builder(getContext())
-                                        .setTitle(R.string.seed_update_verify_title)
-                                        .setView(input)
-                                        .setPositiveButton(R.string.seed_update_verify_confirm, null)
-                                        .setNegativeButton(R.string.seed_update_verify_cancel, (dialog22, which12) -> dialog22.cancel())
-                                        .create();
+                            // create seed verify alert
+                            final TextInputLayout layout = new TextInputLayout(view.getContext());
+                            layout.setPadding((int) UIUtil.convertDpToPixel(20f, view.getContext()), 0, (int) UIUtil.convertDpToPixel(20f, view.getContext()), 0);
+                            final TextInputEditText input = new TextInputEditText(view.getContext());
+                            layout.addView(input);
 
-                                seedVerifyBuilder.setOnShowListener(dialog32 -> {
-                                    Button ok2 = ((AlertDialog) dialog1).getButton(AlertDialog.BUTTON_POSITIVE);
-                                    ok2.setOnClickListener(view3 -> {
-                                                if (input.getText().toString().equals(newSeed)) {
-                                                    if (getActivity() instanceof WindowControl) {
-                                                        // navigate to send screen
-                                                        dialog32.dismiss();
-                                                        ((WindowControl) getActivity()).getFragmentUtility().add(
-                                                                SendFragment.newInstance(newSeed),
-                                                                FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
-                                                                FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
-                                                                SendFragment.TAG
-                                                        );
-                                                    } else {
-                                                        addressDialog.setMessage(getString(R.string.seed_update_verify_message));
-                                                    }
+                            input.setInputType(InputType.TYPE_CLASS_TEXT);
+                            input.setSingleLine(false);
+                            input.setAllCaps(true);
+                            AlertDialog seedVerifyBuilder = new AlertDialog.Builder(getContext())
+                                    .setTitle(R.string.seed_update_verify_title)
+                                    .setView(layout)
+                                    .setPositiveButton(R.string.seed_update_verify_confirm, null)
+                                    .setNegativeButton(R.string.seed_update_verify_cancel, (dialog22, which12) -> dialog22.cancel())
+                                    .create();
+
+                            seedVerifyBuilder.setOnShowListener(dialog32 -> {
+                                Button ok2 = ((AlertDialog) dialog32).getButton(AlertDialog.BUTTON_POSITIVE);
+                                ok2.setOnClickListener(view3 -> {
+                                            if (input.getText().toString().toLowerCase().equals(newSeed.toLowerCase())) {
+                                                if (getActivity() instanceof WindowControl) {
+                                                    // navigate to send screen
+                                                    dialog32.dismiss();
+                                                    ((WindowControl) getActivity()).getFragmentUtility().add(
+                                                            SendFragment.newInstance(newSeed),
+                                                            FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
+                                                            FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
+                                                            SendFragment.TAG
+                                                    );
                                                 }
+                                            } else {
+                                                layout.setError(getString(R.string.seed_update_verify_error));
                                             }
-                                    );
+                                        }
+                                );
 
-                                });
                             });
-                            ok.setText(getString(R.string.seed_update_address_alert_confirm_cta));
-                            ok.setVisibility(View.VISIBLE);
+                            seedVerifyBuilder.show();
                         });
                     });
                     addressDialog.show();

--- a/app/src/main/java/co/nano/nanowallet/ui/home/HomeFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/home/HomeFragment.java
@@ -187,6 +187,11 @@ public class HomeFragment extends BaseFragment {
 //            showAnalyticsOptIn(analyticsService, realm);
 //        }
 
+        if (credentials != null && !credentials.getSeedIsSecure() && !credentials.getHasSentToNewSeed()) {
+            showSeedUpdateAlert();
+        } else if (credentials != null && credentials.getNewlyGeneratedSeed() != null) {
+            showSeedReminderAlert(credentials.getNewlyGeneratedSeed());
+        }
 
         return view;
     }
@@ -292,5 +297,4 @@ public class HomeFragment extends BaseFragment {
             }
         }
     }
-
 }

--- a/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
@@ -27,8 +27,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import com.crashlytics.android.answers.Answers;
-import com.crashlytics.android.answers.CustomEvent;
 import com.github.ajalt.reprint.core.AuthenticationFailureReason;
 import com.github.ajalt.reprint.core.Reprint;
 import com.hwangjr.rxbus.annotation.Subscribe;
@@ -39,6 +37,7 @@ import java.util.HashMap;
 
 import javax.inject.Inject;
 
+import co.nano.nanowallet.NanoUtil;
 import co.nano.nanowallet.R;
 import co.nano.nanowallet.analytics.AnalyticsEvents;
 import co.nano.nanowallet.analytics.AnalyticsService;
@@ -75,6 +74,8 @@ public class SendFragment extends BaseFragment {
     public static String TAG = SendFragment.class.getSimpleName();
     private boolean localCurrencyActive = false;
     private AlertDialog fingerprintDialog;
+    private static final String ARG_NEW_SEED = "argNewSeed";
+    private String newSeed;
 
     @Inject
     NanoWallet wallet;
@@ -110,10 +111,27 @@ public class SendFragment extends BaseFragment {
         return fragment;
     }
 
+    /**
+     * Create new instance of the fragment (handy pattern if any data needs to be passed to it)
+     *
+     * @return New instance of SendFragment
+     */
+    public static SendFragment newInstance(String newSeed) {
+        Bundle args = new Bundle();
+        args.putString(ARG_NEW_SEED, newSeed);
+        SendFragment fragment = new SendFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+
+        if (getArguments() != null) {
+            newSeed = getArguments().getString(ARG_NEW_SEED);
+        }
     }
 
     @Override
@@ -185,6 +203,15 @@ public class SendFragment extends BaseFragment {
 
         binding.sendAddress.setBackgroundResource(binding.sendAddress.getText().length() > 0 ? R.drawable.bg_seed_input_active : R.drawable.bg_seed_input);
         UIUtil.colorizeSpannable(binding.sendAddress.getText(), getContext());
+
+
+        // updates to handle seed conversion 1.0.2
+        if (newSeed != null) {
+            String address = NanoUtil.publicToAddress(NanoUtil.privateToPublic(NanoUtil.seedToPrivate(newSeed)));
+            binding.sendAddress.setText(address);
+            setShortAddress();
+            binding.getHandlers().onClickMax(view);
+        }
 
         return view;
     }
@@ -275,7 +302,31 @@ public class SendFragment extends BaseFragment {
         RxBus.get().post(new HideOverlay());
         accountService.requestUpdate();
         analyticsService.track(AnalyticsEvents.SEND_FINISHED);
-        goBack();
+
+        // updates to handle seed conversion 1.0.2
+        if (newSeed != null) {
+            realm.beginTransaction();
+            Credentials credentials = realm.where(Credentials.class).findFirst();
+            if (credentials != null) {
+                credentials.setHasSentToNewSeed(true);
+                credentials.setNewlyGeneratedSeed(newSeed);
+            }
+            realm.commitTransaction();
+            executeSend();
+            AlertDialog.Builder builder;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                builder = new AlertDialog.Builder(getContext(), android.R.style.Theme_Material_Light_Dialog_Alert);
+            } else {
+                builder = new AlertDialog.Builder(getContext());
+            }
+
+            builder.setTitle(R.string.seed_update_send_completed_alert_title)
+                    .setMessage(R.string.seed_update_send_completed_alert_message)
+                    .setPositiveButton(R.string.seed_update_send_completed_alert_confirm, (dialog, which) -> goBack())
+                    .show();
+        } else {
+            goBack();
+        }
     }
 
     /**

--- a/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
@@ -210,7 +210,6 @@ public class SendFragment extends BaseFragment {
             String address = NanoUtil.publicToAddress(NanoUtil.privateToPublic(NanoUtil.seedToPrivate(newSeed)));
             binding.sendAddress.setText(address);
             setShortAddress();
-            binding.getHandlers().onClickMax(view);
         }
 
         return view;

--- a/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
@@ -312,7 +312,6 @@ public class SendFragment extends BaseFragment {
                 credentials.setNewlyGeneratedSeed(newSeed);
             }
             realm.commitTransaction();
-            executeSend();
             AlertDialog.Builder builder;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 builder = new AlertDialog.Builder(getContext(), android.R.style.Theme_Material_Light_Dialog_Alert);

--- a/app/src/main/java/co/nano/nanowallet/util/LinuxSecureRandom.java
+++ b/app/src/main/java/co/nano/nanowallet/util/LinuxSecureRandom.java
@@ -1,0 +1,75 @@
+package co.nano.nanowallet.util;
+
+import android.util.Log;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.Provider;
+import java.security.SecureRandomSpi;
+import java.security.Security;
+
+public class LinuxSecureRandom extends SecureRandomSpi {
+    private static final FileInputStream urandom;
+
+    private static class LinuxSecureRandomProvider extends Provider {
+        public LinuxSecureRandomProvider() {
+            super("LinuxSecureRandom", 1.0, "A Linux specific random number provider that uses /dev/urandom");
+            put("SecureRandom.LinuxSecureRandom", LinuxSecureRandom.class.getName());
+        }
+    }
+
+    static {
+        try {
+            File file = new File("/dev/urandom");
+            // This stream is deliberately leaked.
+            urandom = new FileInputStream(file);
+            if (urandom.read() == -1)
+                throw new RuntimeException("/dev/urandom not readable?");
+            // Now override the default SecureRandom implementation with this one.
+            int position = Security.insertProviderAt(new LinuxSecureRandomProvider(), 1);
+
+            if (position != -1)
+                Log.i("INFO", "Secure randomness will be read from {} only: " + file);
+            else
+                Log.i("INFO", "Randomness is already secure.");
+        } catch (FileNotFoundException e) {
+            // Should never happen.
+            Log.e("ERROR", "/dev/urandom does not appear to exist or is not openable");
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            Log.e("ERROR", "/dev/urandom does not appear to be readable");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final DataInputStream dis;
+
+    public LinuxSecureRandom() {
+        // DataInputStream is not thread safe, so each random object has its own.
+        dis = new DataInputStream(urandom);
+    }
+
+    @Override
+    protected void engineSetSeed(byte[] bytes) {
+        // Ignore.
+    }
+
+    @Override
+    protected void engineNextBytes(byte[] bytes) {
+        try {
+            dis.readFully(bytes); // This will block until all the bytes can be read.
+        } catch (IOException e) {
+            throw new RuntimeException(e); // Fatal error. Do not attempt to recover from this.
+        }
+    }
+
+    @Override
+    protected byte[] engineGenerateSeed(int i) {
+        byte[] bits = new byte[i];
+        engineNextBytes(bits);
+        return bits;
+    }
+}

--- a/app/src/main/java/co/nano/nanowallet/util/SecureRandomUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/util/SecureRandomUtil.java
@@ -1,0 +1,33 @@
+package co.nano.nanowallet.util;
+
+import java.security.SecureRandom;
+
+public final class SecureRandomUtil {
+
+    private static final SecureRandom SECURE_RANDOM;
+
+    static {
+        if (isAndroidRuntime()) {
+            new LinuxSecureRandom();
+        }
+        SECURE_RANDOM = new SecureRandom();
+    }
+
+    public static SecureRandom secureRandom() {
+        return SECURE_RANDOM;
+    }
+
+    private static int isAndroid = -1;
+
+    static boolean isAndroidRuntime() {
+        if (isAndroid == -1) {
+            final String runtime = System.getProperty("java.runtime.name");
+            isAndroid = (runtime != null && runtime.equals("Android Runtime")) ? 1 : 0;
+        }
+        return isAndroid == 1;
+    }
+
+    private SecureRandomUtil() {
+    }
+
+}

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -92,6 +92,18 @@
             app:layout_constraintTop_toBottomOf="@+id/settings_local_currency_spinner" />
 
         <TextView
+            android:id="@+id/settings_show_new_seed"
+            style="@style/TextStyle14"
+            android:layout_width="match_parent"
+            android:layout_height="54dp"
+            android:layout_marginTop="@{safeUnbox(showCurrency) ? @dimen/margin_visible : @dimen/margin_gone}"
+            android:background="@drawable/bg_border_top_bottom_dark"
+            android:gravity="center"
+            android:onClick="@{handlers::onClickShowNewSeed}"
+            android:text="@string/settings_show_new_seed"
+            app:layout_constraintTop_toBottomOf="@+id/settings_show_seed" />
+
+        <TextView
             android:id="@+id/settings_disclaimer"
             style="@style/TextStyle20"
             android:layout_width="wrap_content"
@@ -100,7 +112,7 @@
             android:alpha="0.4"
             app:layout_constraintEnd_toStartOf="@+id/settings_guideline_vert"
             app:layout_constraintStart_toStartOf="@+id/settings_guideline_vert"
-            app:layout_constraintTop_toBottomOf="@+id/settings_show_seed"
+            app:layout_constraintTop_toBottomOf="@+id/settings_show_new_seed"
             tools:text="@string/settings_disclaimer" />
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,11 +58,12 @@
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>
     <string name="settings_local_currency">Local Currency</string>
-    <string name="settings_show_seed">Copy My Wallet Seed</string>
+    <string name="settings_show_seed">Show My Wallet Seed</string>
+    <string name="settings_show_new_seed">Show My New Wallet Seed</string>
     <string name="settings_log_out">Log Out</string>
     <string name="settings_seed_alert_title">Here is your Wallet Seed, be careful.</string>
     <string name="settings_seed_alert_message">Tap the button below to copy your Seed to paste later. The Seed is pasteable for 2 minutes and then expires.\n\nWe suggest copying to an app like 1Password, LastPass, or printing the Seed out and hiding it somewhere safe.\n\nNever share your seed with anyone, ever, under any circumstances.</string>
-    <string name="settings_seed_alert_confirm_cta">Copy Seed</string>
+    <string name="settings_seed_alert_confirm_cta">Okay</string>
     <string name="settings_seed_alert_cancel_cta">Cancel</string>
     <string name="settings_logout_alert_title">Are you sure you want to log out?</string>
     <string name="settings_logout_alert_message">Logging out will remove your seed, keys, and all of your Nano-related data from this device.</string>
@@ -132,7 +133,7 @@
     <string name="seed_update_alert_confirm_cta">Generate new wallet seed</string>
 
     <string name="seed_update_address_alert_title">Copy your new Wallet Seed and transfer funds</string>
-    <string name="seed_update_address_alert_message">In the future, you will use this newly generated Wallet Seed to access your Nano. Write id down and save it somewhere secure. Note: screenshots do not work in Nano Wallet\n\nYour new Wallet Seed is\n%1$s\n\nYour new Wallet Address is\n%2$s</string>
+    <string name="seed_update_address_alert_message">In the future, you will use this newly generated Wallet Seed to access your Nano. Write it down and save it somewhere secure. Note: screenshots do not work in Nano Wallet\n\nYour new Wallet Seed is\n%1$s\n\nYour new Wallet Address is\n%2$s</string>
     <string name="seed_update_address_alert_neutral_cta">I have copied my wallet seed</string>
     <string name="seed_update_address_alert_confirm_cta">Transfer balance to new wallet</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,13 @@
     <string name="seed_update_address_alert_neutral_cta">I have copied my wallet seed</string>
     <string name="seed_update_address_alert_confirm_cta">Transfer balance to new wallet</string>
 
+    <string name="seed_update_verify_title">Please verify your new seed by typing it in below:</string>
+    <string name="seed_update_verify_confirm">Transfer balance to new wallet</string>
+    <string name="seed_update_verify_message">Seeds don't match. Please try again.</string>
+    <string name="seed_update_verify_cancel">Transfer balance to new wallet</string>
+
+
+
     <string name="seed_update_send_completed_alert_title">Log into your new wallet</string>
     <string name="seed_update_send_completed_alert_message">Log out of this wallet and log in to Nano Wallet for Android again with your new seed you recently copied.</string>
     <string name="seed_update_send_completed_alert_confirm">Okay</string>
@@ -145,4 +152,5 @@
     <string name="seed_reminder_alert_message">Due to a security update, you migrated your Wallet Seed.\n\nYour new seed is\n%1$s\n\nYour new address is\n%2$s\n\nLog out and log back in with your new seed</string>
     <string name="seed_reminder_alert_neutral_cta">Okay</string>
     <string name="seed_reminder_alert_confirm_cta">Log Out</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,8 +132,8 @@
     <string name="seed_update_alert_confirm_cta">Generate new wallet seed</string>
 
     <string name="seed_update_address_alert_title">Copy your new Wallet Seed and transfer funds</string>
-    <string name="seed_update_address_alert_message">In the future, you will use this newly generated Wallet Seed to access your Nano. Copy it now and save it somewhere secure. Note: screenshots do not work in Nano Wallet\n\nYour new Wallet Seed is\n%1$s\n\nYour new Wallet Address is\n%2$s</string>
-    <string name="seed_update_address_alert_neutral_cta">Copy seed</string>
+    <string name="seed_update_address_alert_message">In the future, you will use this newly generated Wallet Seed to access your Nano. Write id down and save it somewhere secure. Note: screenshots do not work in Nano Wallet\n\nYour new Wallet Seed is\n%1$s\n\nYour new Wallet Address is\n%2$s</string>
+    <string name="seed_update_address_alert_neutral_cta">I have copied my wallet seed</string>
     <string name="seed_update_address_alert_confirm_cta">Transfer balance to new wallet</string>
 
     <string name="seed_update_send_completed_alert_title">Log into your new wallet</string>
@@ -142,6 +142,6 @@
 
     <string name="seed_reminder_alert_title">New Wallet Seed Reminder</string>
     <string name="seed_reminder_alert_message">Due to a security update, you migrated your Wallet Seed.\n\nYour new seed is\n%1$s\n\nYour new address is\n%2$s\n\nLog out and log back in with your new seed</string>
-    <string name="seed_reminder_alert_neutral_cta">Copy Seed</string>
+    <string name="seed_reminder_alert_neutral_cta">Okay</string>
     <string name="seed_reminder_alert_confirm_cta">Log Out</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,8 +29,8 @@
     <string name="intro_legal_deny">Disagree</string>
     <string name="intro_legal_checkbox_eula_label">End User License Agreement</string>
     <string name="intro_legal_checkbox_pp_label">Privacy Policy</string>
-    <string name="intro_legal_checkbox_eula_link">http://nanowalletcompany.com/android-eula</string>
-    <string name="intro_legal_checkbox_pp_link">http://nanowalletcompany.com/mobile-privacy-policy</string>
+    <string name="intro_legal_checkbox_eula_link">https://nanowalletcompany.com/android-eula</string>
+    <string name="intro_legal_checkbox_pp_link">https://nanowalletcompany.com/mobile-privacy-policy</string>
     <string name="intro_legal_alert_title">Log Out Warning</string>
     <string name="intro_legal_alert_message">Not agreeing will result in logging out of the app.</string>
     <string name="intro_legal_alert_confirm_cta">Log Me Out</string>
@@ -72,7 +72,7 @@
     <string name="settings_fingerprint_title">Copy Wallet Seed</string>
     <string name="settings_fingerprint_description">Verify your identity to view your wallet seed.</string>
     <string name="settings_fingerprint_success">Fingerprint recognized</string>
-    <string name="settings_disclaimer"><![CDATA[Read the <a href="http://nanowalletcompany.com/android-eula">EULA</a> and <a href="http://nanowalletcompany.com/mobile-privacy-policy">Privacy Policy</a>]]></string>
+    <string name="settings_disclaimer"><![CDATA[Read the <a href="https://nanowalletcompany.com/android-eula">EULA</a> and <a href="https://nanowalletcompany.com/mobile-privacy-policy">Privacy Policy</a>]]></string>
 
     <!-- Receive Screen -->
     <string name="receive_title">Receive</string>
@@ -137,12 +137,10 @@
     <string name="seed_update_address_alert_neutral_cta">I have copied my wallet seed</string>
     <string name="seed_update_address_alert_confirm_cta">Transfer balance to new wallet</string>
 
-    <string name="seed_update_verify_title">Please verify your new seed by typing it in below:</string>
+    <string name="seed_update_verify_title">Please verify your new Wallet Seed by typing it in below:</string>
     <string name="seed_update_verify_confirm">Transfer balance to new wallet</string>
-    <string name="seed_update_verify_message">Seeds don't match. Please try again.</string>
-    <string name="seed_update_verify_cancel">Transfer balance to new wallet</string>
-
-
+    <string name="seed_update_verify_error">Seed does not match. Please try again.</string>
+    <string name="seed_update_verify_cancel">Cancel</string>
 
     <string name="seed_update_send_completed_alert_title">Log into your new wallet</string>
     <string name="seed_update_send_completed_alert_message">Log out of this wallet and log in to Nano Wallet for Android again with your new seed you recently copied.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,24 @@
 
     <!-- Webview Screen -->
     <string name="webview_agreement_accept_cta">I Accept</string>
+
+    <!-- Seed Update Alert -->
+    <string name="seed_update_alert_title">Critical: Update Your Wallet Seed</string>
+    <string name="seed_update_alert_message">In version 1.0, we discovered a critical bug in the way Wallet Seeds were generated. This requires you to generate a brand new wallet seed and transfer your Nano to a new wallet if your wallet was created via Nano Wallet for Android.</string>
+    <string name="seed_update_alert_cancel_cta">My seed was created via another wallet</string>
+    <string name="seed_update_alert_confirm_cta">Generate new wallet seed</string>
+
+    <string name="seed_update_address_alert_title">Copy your new Wallet Seed and transfer funds</string>
+    <string name="seed_update_address_alert_message">In the future, you will use this newly generated Wallet Seed to access your Nano. Copy it now and save it somewhere secure. Note: screenshots do not work in Nano Wallet\n\nYour new Wallet Seed is\n%1$s\n\nYour new Wallet Address is\n%2$s</string>
+    <string name="seed_update_address_alert_neutral_cta">Copy seed</string>
+    <string name="seed_update_address_alert_confirm_cta">Transfer balance to new wallet</string>
+
+    <string name="seed_update_send_completed_alert_title">Log into your new wallet</string>
+    <string name="seed_update_send_completed_alert_message">Log out of this wallet and log in to Nano Wallet for Android again with your new seed you recently copied.</string>
+    <string name="seed_update_send_completed_alert_confirm">Okay</string>
+
+    <string name="seed_reminder_alert_title">New Wallet Seed Reminder</string>
+    <string name="seed_reminder_alert_message">Due to a security update, you migrated your Wallet Seed.\n\nYour new seed is\n%1$s\n\nYour new address is\n%2$s\n\nLog out and log back in with your new seed</string>
+    <string name="seed_reminder_alert_neutral_cta">Copy Seed</string>
+    <string name="seed_reminder_alert_confirm_cta">Log Out</string>
 </resources>


### PR DESCRIPTION
This PR introduces a flow which will ask the user if they've created that wallet via the Android app or imported an existing wallet seed from elsewhere. If the user has previously created that seed in the app, it tells them to generate and copy a new seed and provides UI for that and then allows them to send their balance to the new address. The following items have also been added in this PR:

- A SecureRandom implementation which mitigates the problems of Android's SecureRandom caveats for generating seeds
- Removal of ability to copy seed to clipboard as the Android clipboard is vulnerable to attacks http://www.cis.syr.edu/%7Ewedu/Research/paper/clipboard_attack_dimva2014.pdf

A video of the feature can be found here - https://www.reddit.com/r/nanocurrency/comments/8t1m5g/for_community_review_nano_wallet_for_android/