### PR TITLE
Refactored SharedPreferencesUtil

### DIFF
--- a/app/src/main/java/co/nano/nanowallet/MainActivity.java
+++ b/app/src/main/java/co/nano/nanowallet/MainActivity.java
@@ -47,21 +47,27 @@ import io.realm.Realm;
 import io.realm.RealmResults;
 
 public class MainActivity extends AppCompatActivity implements WindowControl, ActivityWithComponent {
-    protected ActivityComponent mActivityComponent;
-    @Inject
-    Realm realm;
-    @Inject
-    AccountService accountService;
-    @Inject
-    NanoWallet nanoWallet;
-    @Inject
-    SharedPreferencesUtil sharedPreferencesUtil;
-    @Inject
-    AnalyticsService analyticsService;
     private FragmentUtility mFragmentUtility;
     private Toolbar mToolbar;
     private TextView mToolbarTitle;
+    protected ActivityComponent mActivityComponent;
     private FrameLayout mOverlay;
+
+    @Inject
+    Realm realm;
+
+    @Inject
+    AccountService accountService;
+
+    @Inject
+    NanoWallet nanoWallet;
+
+    @Inject
+    SharedPreferencesUtil sharedPreferencesUtil;
+
+    @Inject
+    AnalyticsService analyticsService;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/co/nano/nanowallet/MainActivity.java
+++ b/app/src/main/java/co/nano/nanowallet/MainActivity.java
@@ -217,7 +217,7 @@ public class MainActivity extends AppCompatActivity implements WindowControl, Ac
 
 
         //  if preferences have successfully been saved, go to the welcome fragment
-        if (sharedPreferencesUtil.setFromNewWallet(false) && sharedPreferencesUtil.setConfirmedSeedBackedUp(false)) {
+        if (sharedPreferencesUtil.setFromNewWallet(false, false) && sharedPreferencesUtil.setConfirmedSeedBackedUp(false)) {
             getFragmentUtility().clearStack();
             getFragmentUtility().replace(new IntroWelcomeFragment(), FragmentUtility.Animation.CROSSFADE);
         }

--- a/app/src/main/java/co/nano/nanowallet/MainActivity.java
+++ b/app/src/main/java/co/nano/nanowallet/MainActivity.java
@@ -46,26 +46,21 @@ import io.realm.Realm;
 import io.realm.RealmResults;
 
 public class MainActivity extends AppCompatActivity implements WindowControl, ActivityWithComponent {
+    protected ActivityComponent mActivityComponent;
+    @Inject
+    Realm realm;
+    @Inject
+    AccountService accountService;
+    @Inject
+    NanoWallet nanoWallet;
+    @Inject
+    SharedPreferencesUtil sharedPreferencesUtil;
+    @Inject
+    AnalyticsService analyticsService;
     private FragmentUtility mFragmentUtility;
     private Toolbar mToolbar;
     private TextView mToolbarTitle;
-    protected ActivityComponent mActivityComponent;
     private FrameLayout mOverlay;
-
-    @Inject
-    Realm realm;
-
-    @Inject
-    AccountService accountService;
-
-    @Inject
-    NanoWallet nanoWallet;
-
-    @Inject
-    SharedPreferencesUtil sharedPreferencesUtil;
-
-    @Inject
-    AnalyticsService analyticsService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -213,12 +208,12 @@ public class MainActivity extends AppCompatActivity implements WindowControl, Ac
         // null out component
         mActivityComponent = null;
 
-        sharedPreferencesUtil.setConfirmedSeedBackedUp(false);
-        sharedPreferencesUtil.setFromNewWallet(false);
 
-        // go to the welcome fragment
-        getFragmentUtility().clearStack();
-        getFragmentUtility().replace(new IntroWelcomeFragment(), FragmentUtility.Animation.CROSSFADE);
+        //  if preferences have successfully been saved, go to the welcome fragment
+        if (sharedPreferencesUtil.setFromNewWallet(false) && sharedPreferencesUtil.setConfirmedSeedBackedUp(false)) {
+            getFragmentUtility().clearStack();
+            getFragmentUtility().replace(new IntroWelcomeFragment(), FragmentUtility.Animation.CROSSFADE);
+        }
     }
 
     @Subscribe
@@ -244,7 +239,6 @@ public class MainActivity extends AppCompatActivity implements WindowControl, Ac
     public FragmentUtility getFragmentUtility() {
         return mFragmentUtility;
     }
-
 
 
     /**

--- a/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
@@ -7,16 +7,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.crashlytics.android.answers.Answers;
-import com.crashlytics.android.answers.CustomEvent;
-
 import javax.inject.Inject;
 
 import co.nano.nanowallet.BuildConfig;
 import co.nano.nanowallet.NanoUtil;
 import co.nano.nanowallet.R;
-import co.nano.nanowallet.analytics.AnalyticsEvents;
-import co.nano.nanowallet.analytics.AnalyticsService;
 import co.nano.nanowallet.databinding.FragmentIntroWelcomeBinding;
 import co.nano.nanowallet.model.Credentials;
 import co.nano.nanowallet.ui.common.ActivityWithComponent;
@@ -31,14 +26,12 @@ import io.realm.Realm;
  */
 
 public class IntroWelcomeFragment extends BaseFragment {
-    private FragmentIntroWelcomeBinding binding;
     public static String TAG = IntroWelcomeFragment.class.getSimpleName();
-
     @Inject
     Realm realm;
-
     @Inject
     SharedPreferencesUtil sharedPreferencesUtil;
+    private FragmentIntroWelcomeBinding binding;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -74,13 +67,13 @@ public class IntroWelcomeFragment extends BaseFragment {
                     credentials.setSeed(NanoUtil.generateSeed());
                 });
                 // if this preference was saved successfully, launch the Legal Fragment
-                if (sharedPreferencesUtil.setFromNewWallet(true))
-                ((WindowControl) getActivity()).getFragmentUtility().replace(
-                        IntroLegalFragment.newInstance(),
-                        FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
-                        FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
-                        IntroLegalFragment.TAG
-                );
+                if (sharedPreferencesUtil.setFromNewWallet(true, false)) {
+                    showIntoLegalFragment();
+                }else{ // otherwise save preference in the background thread
+                    sharedPreferencesUtil.setFromNewWallet(true, true);
+                    showIntoLegalFragment();
+
+                }
             }
         }
 
@@ -95,6 +88,15 @@ public class IntroWelcomeFragment extends BaseFragment {
                 );
             }
         }
+    }
+
+    private void showIntoLegalFragment() {
+        ((WindowControl) getActivity()).getFragmentUtility().replace(
+                IntroLegalFragment.newInstance(),
+                FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
+                FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
+                IntroLegalFragment.TAG
+        );
     }
 
 }

--- a/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
@@ -93,8 +93,4 @@ public class IntroWelcomeFragment extends BaseFragment {
         }
     }
 
-    private void showIntoLegalFragment() {
-
-    }
-
 }

--- a/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
@@ -66,14 +66,17 @@ public class IntroWelcomeFragment extends BaseFragment {
                     Credentials credentials = realm.createObject(Credentials.class);
                     credentials.setSeed(NanoUtil.generateSeed());
                 });
-                // if this preference was saved successfully, launch the Legal Fragment
-                if (sharedPreferencesUtil.setFromNewWallet(true, false)) {
-                    showIntoLegalFragment();
-                }else{ // otherwise save preference in the background thread
+                // if this preference wasn't saved successfully, save it in the background
+                if (!sharedPreferencesUtil.setFromNewWallet(true, false)) {
                     sharedPreferencesUtil.setFromNewWallet(true, true);
-                    showIntoLegalFragment();
-
                 }
+
+                ((WindowControl) getActivity()).getFragmentUtility().replace(
+                        IntroLegalFragment.newInstance(),
+                        FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
+                        FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
+                        IntroLegalFragment.TAG
+                );
             }
         }
 
@@ -91,12 +94,7 @@ public class IntroWelcomeFragment extends BaseFragment {
     }
 
     private void showIntoLegalFragment() {
-        ((WindowControl) getActivity()).getFragmentUtility().replace(
-                IntroLegalFragment.newInstance(),
-                FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,
-                FragmentUtility.Animation.ENTER_RIGHT_EXIT_LEFT,
-                IntroLegalFragment.TAG
-        );
+
     }
 
 }

--- a/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/intro/IntroWelcomeFragment.java
@@ -2,6 +2,7 @@ package co.nano.nanowallet.ui.intro;
 
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,7 +41,7 @@ public class IntroWelcomeFragment extends BaseFragment {
     SharedPreferencesUtil sharedPreferencesUtil;
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // init dependency injection
         if (getActivity() instanceof ActivityWithComponent) {
@@ -72,8 +73,8 @@ public class IntroWelcomeFragment extends BaseFragment {
                     Credentials credentials = realm.createObject(Credentials.class);
                     credentials.setSeed(NanoUtil.generateSeed());
                 });
-
-                sharedPreferencesUtil.setFromNewWallet(true);
+                // if this preference was saved successfully, launch the Legal Fragment
+                if (sharedPreferencesUtil.setFromNewWallet(true))
                 ((WindowControl) getActivity()).getFragmentUtility().replace(
                         IntroLegalFragment.newInstance(),
                         FragmentUtility.Animation.ENTER_LEFT_EXIT_RIGHT,

--- a/app/src/main/java/co/nano/nanowallet/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/util/SharedPreferencesUtil.java
@@ -35,7 +35,7 @@ public class SharedPreferencesUtil {
         return mPrefs.getBoolean(key, defValue);
     }
 
-    private void set(String key, String value) {
+    private boolean set(String key, String value) {
         SharedPreferences.Editor editor = mPrefs.edit();
 
         if (value != null) {
@@ -44,15 +44,15 @@ public class SharedPreferencesUtil {
             editor.remove(key);
         }
 
-        editor.apply();
+        return editor.commit();
     }
 
-    private void set(String key, boolean value) {
+    private boolean set(String key, boolean value) {
         SharedPreferences.Editor editor = mPrefs.edit();
 
         editor.putBoolean(key, value);
 
-        editor.apply();
+        return editor.commit();
     }
 
     public boolean hasLocalCurrency() {
@@ -67,8 +67,8 @@ public class SharedPreferencesUtil {
         set(LOCAL_CURRENCY, localCurrency.toString());
     }
 
-    public void clearLocalCurrency() {
-        set(LOCAL_CURRENCY, null);
+    public boolean clearLocalCurrency() {
+        return set(LOCAL_CURRENCY, null);
     }
 
     public boolean hasAppInstallUuid() {
@@ -95,8 +95,8 @@ public class SharedPreferencesUtil {
         return get(FROM_NEW_WALLET, false);
     }
 
-    public void setFromNewWallet(Boolean fromNewWallet) {
-        set(FROM_NEW_WALLET, fromNewWallet);
+    public boolean setFromNewWallet(Boolean fromNewWallet) {
+        return set(FROM_NEW_WALLET, fromNewWallet);
     }
 
     public void clearFromNewWallet() {
@@ -111,17 +111,16 @@ public class SharedPreferencesUtil {
         return get(CONFIRMED_SEED_BACKEDUP, false);
     }
 
-    public void setConfirmedSeedBackedUp(Boolean confirmedSeedBackedUp) {
-        set(CONFIRMED_SEED_BACKEDUP, confirmedSeedBackedUp);
+    public boolean setConfirmedSeedBackedUp(Boolean confirmedSeedBackedUp) {
+        return set(CONFIRMED_SEED_BACKEDUP, confirmedSeedBackedUp);
     }
 
-    public void clearConfirmedSeedBackedUp() {
-        set(CONFIRMED_SEED_BACKEDUP, false);
+    public boolean clearConfirmedSeedBackedUp() {
+        return set(CONFIRMED_SEED_BACKEDUP, false);
     }
 
-    public void clearAll() {
-        clearLocalCurrency();
-        clearConfirmedSeedBackedUp();
+    public boolean clearAll() {
+        return clearLocalCurrency() && clearConfirmedSeedBackedUp();
     }
 
 }

--- a/app/src/main/java/co/nano/nanowallet/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/util/SharedPreferencesUtil.java
@@ -55,6 +55,14 @@ public class SharedPreferencesUtil {
         return editor.commit();
     }
 
+    private void setInBackground(String key, boolean value) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+
+        editor.putBoolean(key, value);
+
+        editor.apply();
+    }
+
     public boolean hasLocalCurrency() {
         return has(LOCAL_CURRENCY);
     }
@@ -95,7 +103,11 @@ public class SharedPreferencesUtil {
         return get(FROM_NEW_WALLET, false);
     }
 
-    public boolean setFromNewWallet(Boolean fromNewWallet) {
+    public boolean setFromNewWallet(Boolean fromNewWallet, Boolean inBackground) {
+        if (inBackground) {
+            setInBackground(FROM_NEW_WALLET, fromNewWallet);
+            return true;
+        }
         return set(FROM_NEW_WALLET, fromNewWallet);
     }
 

--- a/app/src/main/res/layout/fragment_intro_seed.xml
+++ b/app/src/main/res/layout/fragment_intro_seed.xml
@@ -113,7 +113,7 @@
                 android:onClick="@{handlers::onClickCamera}"
                 android:paddingBottom="43dp"
                 android:paddingEnd="20dp"
-                android:paddingRight="20dp"
+                android:paddingStart="20dp"
                 android:paddingTop="43dp"
                 app:layout_constraintEnd_toEndOf="@+id/intro_seed_seed"
                 app:layout_constraintTop_toTopOf="@+id/intro_seed_seed"


### PR DESCRIPTION
The shared preference calls were changed to use the .commit() call instead of the .apply() call. This may avoid issues with the preferences not saving on certain devices or due to restricted memory.