### PR TITLE
Remove seed generator bias

### DIFF
--- a/app/src/main/java/co/nano/nanowallet/NanoUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/NanoUtil.java
@@ -25,11 +25,14 @@ public class NanoUtil {
     public static String generateSeed() {
         int numchars = 64;
         SecureRandom random = SecureRandomUtil.secureRandom();
-        StringBuilder sb = new StringBuilder();
-        while (sb.length() < numchars) {
-            sb.append(Integer.toHexString(random.nextInt()));
+        byte[] randomBytes = new byte[numchars / 2];
+        random.nextBytes(randomBytes);
+      
+        StringBuilder sb = new StringBuilder(numchars);
+        for(byte b: randomBytes){        
+            sb.append(String.format("%02x", b));
         }
-        return sb.toString().substring(0, numchars).toUpperCase();
+        return sb.toString().toUpperCase();
     }
 
     /**

--- a/app/src/main/java/co/nano/nanowallet/NanoUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/NanoUtil.java
@@ -30,9 +30,9 @@ public class NanoUtil {
       
         StringBuilder sb = new StringBuilder(numchars);
         for(byte b: randomBytes){        
-            sb.append(String.format("%02x", b));
+            sb.append(String.format("%02X", b));
         }
-        return sb.toString().toUpperCase();
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
The old code discards hex digits that are 0, and therefore biases the seed towards more 1 bits. This resolves this by making sure every byte is encoded to two hex digits.