### PR TITLE
Removed Jackson dependency in favor of Gson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ local.properties
 .idea/scopes/scope_settings.xml
 .idea/runConfigurations.xml
 .idea/vcs.xml
-.idea/codeStyles/Project.xml
+.idea/codeStyles/
 .idea/caches/build_file_checksums.ser
+.idea/dictionaries/
+.idea/inspectionProfiles/
 *.iml
 
 # OS-specific files

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,9 +101,6 @@ dependencies {
     // JSON Serialization
     implementation "com.google.code.gson:gson:$GSON_VERSION"
     implementation "io.gsonfire:gson-fire:$GSON_FIRE_VERSION"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.9.4"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.9.4"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.9.4"
 
     // Fingerprint
     implementation "com.github.ajalt.reprint:core:$FINGERPRINT_VERSION@aar"

--- a/app/src/androidTest/java/co/nano/nanowallet/network/model/BlockSerializationTest.java
+++ b/app/src/androidTest/java/co/nano/nanowallet/network/model/BlockSerializationTest.java
@@ -1,0 +1,34 @@
+package co.nano.nanowallet.network.model;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.junit.Test;
+
+import co.nano.nanowallet.network.model.request.block.OpenBlock;
+
+import static org.junit.Assert.assertEquals;
+
+public class BlockSerializationTest {
+    @Test
+    public void preserveFieldOrder() {
+        String privateKey = "C5469190B25E850CED298E57723258F716A4E1956AC2BC60DA023300476D1212";
+        String source = "3CD78EE059E404252669B37E8195C7AD4FC6CAEA5AA2C0A4989CF9AB248B4949";
+        String representative = "xrb_3crzecs58y9gd1ucqcfcdsh56ywty5ixzqk41oa5d3i1ggm4bd6c9q5u34m3";
+        //String work = "0000000000000000";
+
+        OpenBlock openBlock = new OpenBlock(privateKey, source, representative);
+        //openBlock.setWork(work);
+
+        JsonObject expected = new JsonObject();
+        expected.addProperty("type", "open");
+        expected.addProperty("source", "3CD78EE059E404252669B37E8195C7AD4FC6CAEA5AA2C0A4989CF9AB248B4949");
+        expected.addProperty("representative", "xrb_3crzecs58y9gd1ucqcfcdsh56ywty5ixzqk41oa5d3i1ggm4bd6c9q5u34m3");
+        expected.addProperty("account", "xrb_39c99zaeon8n9qdsq9ywojqytnhfwzmr6yfaa734k369sy56q4whb1iu45sg");
+        //expected.addProperty("work", "0000000000000000");
+        expected.addProperty("signature", "1C0F0BADDB432D5DB3862D58801D87CCB8915165D2BE02434EB76F2EC71C7B6E66F39964942FF1F0B15D2C6B53A8C73A03785ACEB78574C762EF3354E09D0408");
+
+        Gson gson = new Gson();
+        assertEquals(expected, gson.toJsonTree(openBlock));
+    }
+}

--- a/app/src/main/java/co/nano/nanowallet/di/activity/ActivityModule.java
+++ b/app/src/main/java/co/nano/nanowallet/di/activity/ActivityModule.java
@@ -2,11 +2,8 @@ package co.nano.nanowallet.di.activity;
 
 import android.content.Context;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 
 import co.nano.nanowallet.model.NanoWallet;
 import co.nano.nanowallet.network.AccountService;
@@ -24,7 +21,6 @@ import co.nano.nanowallet.network.model.response.SubscribeResponse;
 import co.nano.nanowallet.network.model.response.TransactionResponse;
 import co.nano.nanowallet.network.model.response.WarningResponse;
 import co.nano.nanowallet.network.model.response.WorkResponse;
-import co.nano.nanowallet.util.ExceptionHandler;
 import dagger.Module;
 import dagger.Provides;
 import io.gsonfire.GsonFireBuilder;
@@ -107,7 +103,6 @@ public class ActivityModule {
                             src.getAsJsonObject().addProperty("messageType", Actions.PROCESS.toString());
                         } else if (src.getAsJsonObject().get("contents") != null) {
                             // get block response
-                            ObjectMapper mapper = new ObjectMapper();
                             String content = src.getAsJsonObject().get("contents").getAsString();
                             content = content.replace("\n", "");
                             content = content.replace("\\\"", "\"");

--- a/app/src/main/java/co/nano/nanowallet/network/AccountService.java
+++ b/app/src/main/java/co/nano/nanowallet/network/AccountService.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.internal.LinkedTreeMap;
@@ -495,14 +493,7 @@ public class AccountService {
 
                 if (requestItem.getRequest() instanceof Block) {
                     // escape the block to match https://github.com/clemahieu/raiblocks/wiki/RPC-protocol#process-block
-                    // use jackson here to maintain field order
-                    ObjectMapper mapper = new ObjectMapper();
-                    String block = "";
-                    try {
-                        block = mapper.writeValueAsString(requestItem.getRequest());
-                    } catch (JsonProcessingException e) {
-                        ExceptionHandler.handle(e);
-                    }
+                    String block = gson.toJson(requestItem.getRequest());
 
                     checkState();
                     Timber.d("SEND: %s", gson.toJson(new ProcessRequest(block)));
@@ -513,7 +504,7 @@ public class AccountService {
                         processQueue();
                     } else if ((requestItem.getRequest() instanceof StateBlock) &&
                             (((Block) requestItem.getRequest()).getInternal_block_type() == BlockTypes.SEND ||
-                            ((Block) requestItem.getRequest()).getInternal_block_type() == BlockTypes.RECEIVE) &&
+                                    ((Block) requestItem.getRequest()).getInternal_block_type() == BlockTypes.RECEIVE) &&
                             ((StateBlock) requestItem.getRequest()).getBalance() == null) {
                         ExceptionHandler.handle(new Exception("Head block request failed."));
                         requestQueue.poll();
@@ -655,8 +646,8 @@ public class AccountService {
     /**
      * Make a no-op request
      *
-     * @param previous    Previous hash
-     * @param balance     Current Wallet Balance
+     * @param previous       Previous hash
+     * @param balance        Current Wallet Balance
      * @param representative Represnetative
      */
     public void requestChange(String previous, BigInteger balance, String representative, boolean noop) {
@@ -748,7 +739,7 @@ public class AccountService {
         for (RequestItem item : requestQueue) {
             if (item.getRequest() instanceof OpenBlock ||
                     (item.getRequest() instanceof StateBlock &&
-                    ((StateBlock) item.getRequest()).getInternal_block_type().equals(BlockTypes.OPEN))) {
+                            ((StateBlock) item.getRequest()).getInternal_block_type().equals(BlockTypes.OPEN))) {
                 return true;
             }
         }

--- a/app/src/main/java/co/nano/nanowallet/network/model/request/block/Block.java
+++ b/app/src/main/java/co/nano/nanowallet/network/model/request/block/Block.java
@@ -1,8 +1,5 @@
 package co.nano.nanowallet.network.model.request.block;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.SerializedName;
 
 import co.nano.nanowallet.network.model.BlockTypes;
@@ -10,13 +7,11 @@ import co.nano.nanowallet.network.model.BlockTypes;
 /**
  * Base block
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Block {
     @SerializedName("work")
     protected String work;
 
-    @SerializedName("internal_block_type")
-    private BlockTypes internal_block_type;
+    private transient BlockTypes internal_block_type;
 
     public String getWork() {
         return work;
@@ -26,7 +21,6 @@ public class Block {
         this.work = work;
     }
 
-    @JsonIgnore
     public BlockTypes getInternal_block_type() {
         return internal_block_type;
     }

--- a/app/src/main/java/co/nano/nanowallet/network/model/request/block/OpenBlock.java
+++ b/app/src/main/java/co/nano/nanowallet/network/model/request/block/OpenBlock.java
@@ -1,6 +1,5 @@
 package co.nano.nanowallet.network.model.request.block;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.gson.annotations.SerializedName;
 
 import co.nano.nanowallet.NanoUtil;
@@ -10,14 +9,6 @@ import co.nano.nanowallet.network.model.BlockTypes;
  * Subscribe to websocket server for updates regarding the specified account.
  * First action to take when connecting when app opens or reconnects, IF a wallet already exists
  */
-@JsonPropertyOrder({
-        "type",
-        "source",
-        "representative",
-        "account",
-        "work",
-        "signature"
-})
 public class OpenBlock extends Block {
     @SerializedName("type")
     private String type;

--- a/app/src/main/java/co/nano/nanowallet/network/model/request/block/ReceiveBlock.java
+++ b/app/src/main/java/co/nano/nanowallet/network/model/request/block/ReceiveBlock.java
@@ -1,6 +1,5 @@
 package co.nano.nanowallet.network.model.request.block;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.gson.annotations.SerializedName;
 
 import co.nano.nanowallet.NanoUtil;
@@ -10,27 +9,20 @@ import co.nano.nanowallet.network.model.BlockTypes;
  * Subscribe to websocket server for updates regarding the specified account.
  * First action to take when connecting when app opens or reconnects, IF a wallet already exists
  */
-@JsonPropertyOrder({
-        "type",
-        "source",
-        "previous",
-        "work",
-        "signature"
-})
 public class ReceiveBlock extends Block {
     @SerializedName("type")
     private String type;
 
-    @SerializedName("previous")
-    private String previous;
-
     @SerializedName("source")
     private String source;
+
+    @SerializedName("previous")
+    private String previous;
 
     @SerializedName("signature")
     private String signature;
 
-    private String private_key;
+    private transient String private_key;
 
     public ReceiveBlock() {
         this.type = BlockTypes.RECEIVE.toString();
@@ -53,6 +45,14 @@ public class ReceiveBlock extends Block {
         this.type = type;
     }
 
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
     public String getPrevious() {
         return previous;
     }
@@ -61,14 +61,6 @@ public class ReceiveBlock extends Block {
         this.previous = previous;
         String hash = NanoUtil.computeReceiveHash(previous, this.source);
         this.signature = NanoUtil.sign(this.private_key, hash);
-    }
-
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(String source) {
-        this.source = source;
     }
 
     public String getSignature() {

--- a/app/src/main/java/co/nano/nanowallet/network/model/request/block/SendBlock.java
+++ b/app/src/main/java/co/nano/nanowallet/network/model/request/block/SendBlock.java
@@ -1,7 +1,6 @@
 package co.nano.nanowallet.network.model.request.block;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.google.gson.annotations.SerializedName;
 
 import co.nano.nanowallet.NanoUtil;
 import co.nano.nanowallet.network.model.BlockTypes;
@@ -10,28 +9,20 @@ import co.nano.nanowallet.util.NumberUtil;
 /**
  * Send BlockItem
  */
-@JsonPropertyOrder({
-        "type",
-        "previous",
-        "destination",
-        "balance",
-        "work",
-        "signature"
-})
 public class SendBlock extends Block {
-    @JsonProperty("type")
+    @SerializedName("type")
     private String type;
 
-    @JsonProperty("previous")
+    @SerializedName("previous")
     private String previous;
 
-    @JsonProperty("destination")
+    @SerializedName("destination")
     private String destination;
 
-    @JsonProperty("balance")
+    @SerializedName("balance")
     private String balance;
 
-    @JsonProperty("signature")
+    @SerializedName("signature")
     private String signature;
 
     public SendBlock() {

--- a/app/src/main/java/co/nano/nanowallet/network/model/request/block/StateBlock.java
+++ b/app/src/main/java/co/nano/nanowallet/network/model/request/block/StateBlock.java
@@ -1,8 +1,5 @@
 package co.nano.nanowallet.network.model.request.block;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.gson.annotations.SerializedName;
 
 import co.nano.nanowallet.NanoUtil;
@@ -13,43 +10,31 @@ import co.nano.nanowallet.util.NumberUtil;
 /**
  * Send BlockItem
  */
-@JsonPropertyOrder({
-        "type",
-        "previous",
-        "account",
-        "representative",
-        "balance",
-        "link",
-        "work",
-        "signature"
-})
 public class StateBlock extends Block {
-    @JsonProperty("type")
+    @SerializedName("type")
     private String type;
 
-    @JsonProperty("previous")
+    @SerializedName("previous")
     private String previous;
 
-    @JsonProperty("account")
+    @SerializedName("account")
     private String account;
 
-    @JsonProperty("representative")
+    @SerializedName("representative")
     private String representative;
 
-    @JsonProperty("balance")
+    @SerializedName("balance")
     private String balance;
 
-    @JsonProperty("link")
+    @SerializedName("link")
     private String link;
 
-    @JsonProperty("signature")
+    @SerializedName("signature")
     private String signature;
 
-    @SerializedName("sendAmount")
-    private String sendAmount;
-
-    private String privateKey;
-    private String publicKey;
+    private transient String sendAmount;
+    private transient String privateKey;
+    private transient String publicKey;
 
     public StateBlock() {
         this.type = BlockTypes.STATE.toString();
@@ -157,7 +142,6 @@ public class StateBlock extends Block {
         this.signature = signature;
     }
 
-    @JsonIgnore
     public String getSendAmount() {
         return sendAmount;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Workaround for incremental compilation in tests. Had to clean project between test runs without it.
+android.enableIncrementalDesugaring=false


### PR DESCRIPTION
Since field order in JSON does not matter, dependency on Jackson is completely unnecessary. This pull request removes that dependency, configuring classes to work properly with Gson instead.

Benefits:
- consistent serialization
- shaved off ~540 KB from release apk size