### PR TITLE
Support for nano_ prefix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
     dataBinding {
         enabled = true
     }

--- a/app/src/main/java/co/nano/nanowallet/NanoUtil.java
+++ b/app/src/main/java/co/nano/nanowallet/NanoUtil.java
@@ -262,7 +262,7 @@ public class NanoUtil {
         reverse(check_b);
 
         StringBuilder resultAddress = new StringBuilder();
-        resultAddress.insert(0, "xrb_");
+        resultAddress.insert(0, "nano_");
         resultAddress.append(encodedAddress);
         resultAddress.append(encode(NanoUtil.bytesToHex(check_b)));
 

--- a/app/src/main/java/co/nano/nanowallet/model/Address.java
+++ b/app/src/main/java/co/nano/nanowallet/model/Address.java
@@ -14,6 +14,8 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import co.nano.nanowallet.NanoUtil;
 
@@ -31,8 +33,7 @@ public class Address implements Serializable {
     }
 
     public Address(String value) {
-        this.value = value;
-        parseAddress();
+        this.value = parseAddress(value);
     }
 
     public boolean hasXrbAddressFormat() {
@@ -116,25 +117,39 @@ public class Address implements Serializable {
         return true;
     }
 
-    private void parseAddress() {
-        if (this.value != null) {
-            String[] _split = value.split(":");
+    private String parseAddress(String addressString) {
+        String ret;
+        if (addressString != null) {
+            addressString = addressString.toLowerCase();
+            ret = findAddress(addressString);
+            String[] _split = addressString.split(":");
             if (_split.length > 1) {
                 String _addressString = _split[1];
                 Uri uri = Uri.parse(_addressString);
-                if (uri.getPath() != null) {
-                    this.value = uri.getPath();
-                }
                 if (uri.getQueryParameter("amount") != null && !uri.getQueryParameter("amount").equals("")) {
                     try {
-                        this.amount = (new BigDecimal(uri.getQueryParameter("amount")).divide(RAW_PER_NANO)).toString();
+                        this.amount = (new BigDecimal(uri.getQueryParameter("amount"))).toString();
                     } catch (NumberFormatException e) {
                     }
                 }
             }
-
+            return ret;
         }
-
+        return null;
     }
 
+    /**
+     * findAddress - Finds a ban_ address in a string
+     *
+     * @param address
+     * @return
+     */
+    public static final String findAddress(String address) {
+        Pattern p = Pattern.compile("(xrb|nano)(_)(1|3)[13456789abcdefghijkmnopqrstuwxyz]{59}");
+        Matcher matcher = p.matcher(address);
+        if (matcher.find()) {
+            return matcher.group(0);
+        }
+        return "";
+    }
 }

--- a/app/src/main/java/co/nano/nanowallet/model/NanoWallet.java
+++ b/app/src/main/java/co/nano/nanowallet/model/NanoWallet.java
@@ -53,6 +53,7 @@ public class NanoWallet {
 
     // for sending
     private String sendNanoAmount;
+    private String sendRawAmount;
     private String sendLocalCurrencyAmount;
     private String publicKey;
 
@@ -179,6 +180,15 @@ public class NanoWallet {
     }
 
     /**
+     * Get RAW amount set for send
+     *
+     * @return String
+     */
+    public String getSendRawAmount() {
+        return sendRawAmount;
+    }
+
+    /**
      * Return the currency formatted local currency amount as a string
      *
      * @return Formatted Nano amount
@@ -211,13 +221,22 @@ public class NanoWallet {
         return amount.replaceAll("[^\\d.]", "");
     }
 
+    /**
+     * Set RAW amount which will also set nano amount and local currency amount
+     *
+     * @param rawAmount String raw Amount from input
+     */
+    public void setSendRawAmount(String rawAmount) {
+        this.sendRawAmount = rawAmount;
+        this.setSendNanoAmountPreservingRaw(NumberUtil.getRawAsUsableString(rawAmount));
+    }
 
     /**
-     * Set Nano amount which will also set the local currency amount
+     * Get Nano amount entered
      *
-     * @param nanoAmount String Nano Amount from input
+     * @return String
      */
-    public void setSendNanoAmount(String nanoAmount) {
+    private void setSendNanoAmountPreservingRaw(String nanoAmount) {
         this.sendNanoAmount = sanitize(nanoAmount);
         if (nanoAmount.length() > 0) {
             if (this.sendNanoAmount.equals(".")) {
@@ -241,6 +260,16 @@ public class NanoWallet {
             this.sendLocalCurrencyAmount = "";
         }
         validateSendAmount();
+    }
+
+    /**
+     * Set Nano amount which will also set the local currency amount
+     *
+     * @param nanoAmount String Nano Amount from input
+     */
+    public void setSendNanoAmount(String nanoAmount) {
+        this.sendRawAmount = null;
+        setSendNanoAmountPreservingRaw(nanoAmount);
     }
 
     /**

--- a/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
+++ b/app/src/main/java/co/nano/nanowallet/ui/send/SendFragment.java
@@ -239,7 +239,7 @@ public class SendFragment extends BaseFragment {
                     }
 
                     if (address.getAmount() != null) {
-                        wallet.setSendNanoAmount(address.getAmount());
+                        wallet.setSendRawAmount(address.getAmount());
                         binding.setWallet(wallet);
                     }
 
@@ -359,7 +359,12 @@ public class SendFragment extends BaseFragment {
         if (wallet.getSendNanoAmount().isEmpty()) {
             return false;
         }
-        BigInteger balance = NumberUtil.getAmountAsRawBigInteger(wallet.getSendNanoAmount());
+        BigInteger balance;
+        if (wallet.getSendRawAmount() != null) {
+            balance = new BigInteger(wallet.getSendRawAmount());
+        } else {
+            balance = NumberUtil.getAmountAsRawBigInteger(wallet.getSendNanoAmount());
+        }
         if (balance.compareTo(wallet.getAccountBalanceNanoRaw().toBigInteger()) > 0) {
             showError(R.string.send_error_alert_title, R.string.send_error_alert_message);
             return false;
@@ -507,7 +512,12 @@ public class SendFragment extends BaseFragment {
         Address destination = new Address(binding.sendAddress.getText().toString());
         if (destination.isValidAddress()) {
             RxBus.get().post(new ShowOverlay());
-            BigInteger sendAmount = NumberUtil.getAmountAsRawBigInteger(wallet.getSendNanoAmount());
+            BigInteger sendAmount;
+            if (wallet.getSendRawAmount() != null) {
+                sendAmount = new BigInteger(wallet.getSendRawAmount());
+            } else {
+                sendAmount = NumberUtil.getAmountAsRawBigInteger(wallet.getSendNanoAmount());
+            }
 
             accountService.requestSend(wallet.getFrontierBlock(), destination, sendAmount);
             analyticsService.track(AnalyticsEvents.SEND_BEGAN);

--- a/app/src/main/res/layout/fragment_receive.xml
+++ b/app/src/main/res/layout/fragment_receive.xml
@@ -105,6 +105,7 @@
         <TextView
             android:id="@+id/receive_address"
             style="@style/SeedText"
+            android:maxLength="65"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:layout_marginEnd="45dp"

--- a/app/src/main/res/layout/fragment_send.xml
+++ b/app/src/main/res/layout/fragment_send.xml
@@ -30,6 +30,7 @@
         <EditText
             android:id="@+id/send_address"
             style="@style/SeedInput"
+            android:maxLength="65"
             android:layout_height="0dp"
             android:layout_marginBottom="20dp"
             android:layout_marginEnd="37dp"
@@ -66,6 +67,7 @@
         <TextView
             android:id="@+id/send_address_display"
             style="@style/SeedInput"
+            android:maxLength="65"
             android:layout_height="0dp"
             android:layout_marginBottom="16dp"
             android:layout_marginEnd="37dp"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "io.realm:realm-gradle-plugin:5.3.1"
         classpath 'io.fabric.tools:gradle:1.+'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 02 11:04:34 EDT 2018
+#Sun Mar 31 16:45:17 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Allow sending to accounts with a `nano_` prefix, display these properly in the UI, and also emit addresses with `nano_` prefix within the app.

This matches the behavior of the upcoming nano node V19 Solidus